### PR TITLE
fix: position and outline of edit profile icon btn on mobile screen (AP-205)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -15,7 +15,7 @@ function EditProfileBtn() {
   return (
     <Link
       href='/'
-      className='bg-primary-green border-3 border-white p-1 rounded-lg relative left-10 bottom-26 lg:static lg:border-none lg:px-4 lg:py-2 lg:mt-4'
+      className='bg-primary-green border-4 border-white p-1 rounded-lg relative left-10 bottom-[110px] lg:static lg:border-none lg:px-4 lg:py-2 lg:mt-4'
     >
       <div className='block lg:hidden'>
         <Pencil size={16} fill='white' />


### PR DESCRIPTION
Hard-coded the px for bottom positioning and changed border to 4.  It seems like only certain values are allowed after some tailwind settings were changed.