### PR TITLE
Feat: added page redirects to tenant dashboard (AP-16)

### DIFF
--- a/src/app/constants/labels.ts
+++ b/src/app/constants/labels.ts
@@ -128,22 +128,22 @@ const LABELS = {
   },
   dashboardBtns: {
     viewLease: {
-      href: "/",
+      href: "/lease",
       text: "View Lease",
       icon: "leaseIcon",
     },
     guestParking: {
-      href: "/",
+      href: "/parking",
       text: "Guest Parking Pass",
       icon: "guestParkingIcon",
     },
     viewMessages: {
-      href: "/",
+      href: "/Messaging",
       text: "View Messages",
       icon: "mailIcon",
     },
     viewPackages: {
-      href: "/",
+      href: "/locker",
       text: "View Packages",
       icon: "packagesIcon",
     },
@@ -153,7 +153,7 @@ const LABELS = {
       icon: "problemIcon",
     },
     unlockDoor: {
-      href: "/",
+      href: "/passkey",
       text: "Unlock My Door",
       icon: "unlockIcon",
     },


### PR DESCRIPTION
Very small PR, went into `labels.ts` and changed the the `dashboardBtns` into their respective pages.

The only one not changed was the "report a problem" or "report a noise complaint", because we are going to change out that functionality and it's not going to redirect the user to a new page. That's handled in a new ticket - not this one.