### PR TITLE
Fix: change text reportProblem to report noise complaint (TP-49)

### DIFF
--- a/src/app/constants/labels.ts
+++ b/src/app/constants/labels.ts
@@ -149,7 +149,7 @@ const LABELS = {
     },
     reportProblem: {
       href: "/",
-      text: "Report a Problem",
+      text: "Report a Noise Complaint",
       icon: "problemIcon",
     },
     unlockDoor: {


### PR DESCRIPTION
just changing the text from report a problem to report a noise complaint in the tenant dashboard. very small change