### PR TITLE
fix: consistent space between form fields with or without validation message (TP-62)

### DIFF
--- a/src/app/components/ContactUs.tsx
+++ b/src/app/components/ContactUs.tsx
@@ -5,12 +5,12 @@ import LABELS from "../constants/labels";
 
 function FieldInfo({ field }: { field: AnyFieldApi }) {
   return (
-    <p className="text-red-400 text-sm font-thin ml-2">
+    <div className="h-4 text-red-400 text-sm font-thin ml-2">
       {field.state.meta.isTouched && field.state.meta.errors.length ? (
         <em>{field.state.meta.errors.join(", ")}</em>
       ) : null}
       {field.state.meta.isValidating ? "Validating..." : null}
-    </p>
+    </div>
   );
 }
 


### PR DESCRIPTION
The gap between each form input should remain the same and not push the layout around:

![image](https://github.com/user-attachments/assets/abcdd1f0-f907-4ec7-adba-375b54b99265)

![image](https://github.com/user-attachments/assets/15a3c3cc-ad1a-41db-882d-7e2453dd025f)
