### PR TITLE
feat: conditionally render ChangePasswordForm in the EditProfilePage (TP-66)

### DIFF
--- a/src/app/components/ChangePasswordForm.tsx
+++ b/src/app/components/ChangePasswordForm.tsx
@@ -1,0 +1,118 @@
+'use client';
+import { useForm } from '@tanstack/react-form';
+import type { AnyFieldApi } from '@tanstack/react-form';
+import LABELS from '@/app/constants/labels';
+
+const FieldInfo = ({ field }: { field: AnyFieldApi }) => {
+  return (
+    <div className='h-4 text-alternate-light-gray text-sm font-thin ml-2'>
+      {field.state.meta.isTouched && field.state.meta.errors.length ? (
+        <em>{field.state.meta.errors.join(', ')}</em>
+      ) : null}
+      {field.state.meta.isValidating ? 'Validating...' : null}
+    </div>
+  );
+};
+
+const ChangePasswordForm = () => {
+  const form = useForm({
+    defaultValues: {
+      currPassword: '',
+      newPassword: '',
+    },
+    onSubmit: async ({ value }) => {
+      console.log('Form submitted:', value);
+    },
+  });
+
+  const labelClasses = 'text-white text-xl';
+  const inputClasses =
+    'w-full p-3 bg-[#0F3645] text-white rounded-md focus:outline-none';
+  const btnClasses =
+    'w-full bg-primary-green text-white text-sm lg:text-lg p-3 rounded-md';
+
+  return (
+    <div className='w-full relative bottom-40 px-6 lg:static'>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void form.handleSubmit();
+        }}
+        className='space-y-4 max-w-[400px] mx-auto'
+      >
+        <form.Field
+          name='currPassword'
+          validators={{
+            onChange: ({ value }) =>
+              !value ? 'Current password is required' : undefined,
+            onChangeAsyncDebounceMs: 100,
+            onChangeAsync: async ({ value }) => {
+              await new Promise((resolve) => setTimeout(resolve, 500));
+              return (
+                value.includes('error') &&
+                'No "error" allowed in current password'
+              );
+            },
+          }}
+        >
+          {(field) => (
+            <div>
+              <label htmlFor={field.name} className={labelClasses}>
+                {LABELS.changePassword.formLabels.currPassword}
+              </label>
+              <input
+                className={inputClasses}
+                id={field.name}
+                name={field.name}
+                type='password'
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <FieldInfo field={field} />
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field
+          name='newPassword'
+          validators={{
+            onChange: ({ value }) =>
+              !value ? 'New password is required' : undefined,
+            onChangeAsyncDebounceMs: 100,
+            onChangeAsync: async ({ value }) => {
+              await new Promise((resolve) => setTimeout(resolve, 500));
+              return (
+                value.includes('error') && 'No "error" allowed in new password'
+              );
+            },
+          }}
+        >
+          {(field) => (
+            <div>
+              <label htmlFor={field.name} className={labelClasses}>
+                {LABELS.changePassword.formLabels.newPassword}
+              </label>
+              <input
+                className={inputClasses}
+                id={field.name}
+                name={field.name}
+                type='password'
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <FieldInfo field={field} />
+            </div>
+          )}
+        </form.Field>
+
+        <button type='submit' className={btnClasses}>
+          {LABELS.changePassword.formBtns.submitBtn}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ChangePasswordForm;

--- a/src/app/components/ChangePasswordForm.tsx
+++ b/src/app/components/ChangePasswordForm.tsx
@@ -14,7 +14,13 @@ const FieldInfo = ({ field }: { field: AnyFieldApi }) => {
   );
 };
 
-const ChangePasswordForm = () => {
+interface ChangePasswordFormProps {
+  displayEditProfile: () => void;
+}
+
+const ChangePasswordForm = ({
+  displayEditProfile,
+}: ChangePasswordFormProps) => {
   const form = useForm({
     defaultValues: {
       currPassword: '',
@@ -24,6 +30,10 @@ const ChangePasswordForm = () => {
       console.log('Form submitted:', value);
     },
   });
+
+  const handleCancelClick = () => {
+    displayEditProfile();
+  };
 
   const labelClasses = 'text-white text-xl';
   const inputClasses =
@@ -107,9 +117,18 @@ const ChangePasswordForm = () => {
           )}
         </form.Field>
 
-        <button type='submit' className={btnClasses}>
-          {LABELS.changePassword.formBtns.submitBtn}
-        </button>
+        <div className='flex flex-row gap-4 lg:gap-12 pt-8'>
+          <button
+            type='button'
+            className={btnClasses}
+            onClick={handleCancelClick}
+          >
+            {LABELS.editProfile.formBtns.cancelBtn}
+          </button>
+          <button type='submit' className={btnClasses}>
+            {LABELS.changePassword.formBtns.submitBtn}
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/src/app/components/EditProfileForm.tsx
+++ b/src/app/components/EditProfileForm.tsx
@@ -15,7 +15,13 @@ function FieldInfo({ field }: { field: AnyFieldApi }) {
   );
 }
 
-export default function EditProfileForm() {
+interface EditProfileFormProps {
+  displayChangePassword: () => void;
+}
+
+export default function EditProfileForm({
+  displayChangePassword,
+}: EditProfileFormProps) {
   const [isEmailChanged, setIsEmailChanged] = useState(false);
   // TODO: the default values should come from the logged in users data
   const userName = 'Animal';
@@ -33,7 +39,7 @@ export default function EditProfileForm() {
   });
 
   const handleChangePasswordClick = () => {
-    console.log('Change password clicked');
+    displayChangePassword();
   };
 
   // TODO: add logic for cancel

--- a/src/app/constants/labels.ts
+++ b/src/app/constants/labels.ts
@@ -220,6 +220,17 @@ const LABELS = {
     },
   },
 
+  changePassword: {
+    formLabels: {
+      currPassword: 'Current Password',
+      newPassword: 'New Password',
+    },
+    formBtns: {
+      cancelBtn: 'Cancel',
+      submitBtn: 'Submit',
+    }
+  },
+
   passcode: {
     searchParams: "Loading...",
     title: "New Key Details",

--- a/src/app/editProfile/page.tsx
+++ b/src/app/editProfile/page.tsx
@@ -31,7 +31,7 @@ function ProfileHeader() {
   );
 }
 
-export default function Home() {
+export default function EditProfilePage() {
   return (
     <main className='bg-white relative'>
       <Header />

--- a/src/app/editProfile/page.tsx
+++ b/src/app/editProfile/page.tsx
@@ -1,8 +1,10 @@
 'use client';
+import { useState } from 'react';
 import Header from '@/app/components/Header';
 import Image from 'next/image';
 import LABELS from '@/app/constants/labels';
 import EditProfileForm from '@/app/components/EditProfileForm';
+import ChangePasswordForm from '@/app/components/ChangePasswordForm';
 import Footer from '../components/Footer';
 
 function ApartmentBg() {
@@ -32,13 +34,23 @@ function ProfileHeader() {
 }
 
 export default function EditProfilePage() {
+  const [isChangePasswordDisplayed, setIsChangePasswordDisplayed] =
+    useState(false);
+
+  const displayChangePassword = () => setIsChangePasswordDisplayed(true);
+  const displayEditProfile = () => setIsChangePasswordDisplayed(false);
+
   return (
     <main className='bg-white relative'>
       <Header />
       <ApartmentBg />
       <div className='bg-secondary-blue h-screen flex flex-col items-stretch lg:pt-6'>
         <ProfileHeader />
-        <EditProfileForm />
+        {isChangePasswordDisplayed ? (
+          <ChangePasswordForm displayEditProfile={displayEditProfile} />
+        ) : (
+          <EditProfileForm displayChangePassword={displayChangePassword} />
+        )}
       </div>
       <Footer />
     </main>


### PR DESCRIPTION
The EditProfilePage should have a "Change Password" button:
![image](https://github.com/user-attachments/assets/0073a394-2ed7-4353-9379-434472e78ae9)
Clicking it should change the display to the ChangePasswordForm:
![image](https://github.com/user-attachments/assets/8b0c8369-e328-414d-be7b-9e02527b5997)
From here, clicking the cancel button should take you back to the EditProfileForm:
![image](https://github.com/user-attachments/assets/5408d20a-7ef4-4ce7-b185-52af80f66396)
