### PR TITLE
feat: use real user data and add save changes functionality (TP-68)

### DIFF
--- a/src/app/components/EditProfileForm.tsx
+++ b/src/app/components/EditProfileForm.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useForm } from '@tanstack/react-form';
 import type { AnyFieldApi } from '@tanstack/react-form';
 import LABELS from '@/app/constants/labels';
+import { useRouter } from 'next/navigation';
 
 function FieldInfo({ field }: { field: AnyFieldApi }) {
   return (
@@ -38,13 +39,14 @@ export default function EditProfileForm({
     },
   });
 
+  const router = useRouter();
+
   const handleChangePasswordClick = () => {
     displayChangePassword();
   };
 
-  // TODO: add logic for cancel
   const handleCancelClick = () => {
-    console.log('Edit profile cancelled');
+    router.back();
   };
 
   const labelClasses = 'text-white text-xl';

--- a/src/lib/appwrite.ts
+++ b/src/lib/appwrite.ts
@@ -1,10 +1,10 @@
-import { Client, Account } from "appwrite";
+import { Client, Account } from 'appwrite';
 
 // Since everyone on the team is new to Appwrite, we will add comments to explain the code
 // Initialize the Appwrite client
 export const client = new Client()
-  .setEndpoint("https://cloud.appwrite.io/v1") // Your Appwrite API endpoint
-  .setProject(process.env.NEXT_PUBLIC_APPWRITE_PROJECT_ID || ""); // Your project ID, We get this from Appwrite Console and it is required to be in your .env file
+  .setEndpoint('https://cloud.appwrite.io/v1') // Your Appwrite API endpoint
+  .setProject(process.env.NEXT_PUBLIC_APPWRITE_PROJECT_ID || ''); // Your project ID, We get this from Appwrite Console and it is required to be in your .env file
 
 // Initialize the Appwrite account
 export const account = new Account(client);
@@ -24,7 +24,7 @@ export const loginWithEmailPassword = async (
 export const getCurrentUser = async () => {
   try {
     const user = await account.get();
-    console.log("User:", user);
+    console.log('User:', user);
     return { success: true, data: user };
   } catch (error) {
     return { success: false, error };
@@ -46,10 +46,30 @@ export const registerUser = async (
   }
 };
 
+// Update user name and/or email
+export const updateUserProfile = async (
+  name: string,
+  email: string,
+  password: string
+) => {
+  try {
+    if (name) {
+      await account.updateName(name);
+    }
+    if (email && password) {
+      await account.updateEmail(email, password);
+    }
+    const updatedUser = await account.get();
+    return { success: true, data: updatedUser };
+  } catch (error) {
+    return { success: false, error };
+  }
+};
+
 // Logout user
 export const logout = async () => {
   try {
-    await account.deleteSession("current");
+    await account.deleteSession('current');
     return { success: true };
   } catch (error) {
     return { success: false, error };


### PR DESCRIPTION
The EditProfileForm should display real user data:
![image](https://github.com/user-attachments/assets/bbbe3f26-20d0-461c-9445-d5414a59f014)
The cancel btn should route the user back to the dashboard.
Changing the user's name should be reflected in appwrite and in the dashboard:
![image](https://github.com/user-attachments/assets/52ccefab-01f5-4e72-92a0-51ead39454b3)
Attempting to change the user's email should disallow the submission without confirming the password:
![image](https://github.com/user-attachments/assets/bfdaaede-adfa-463d-9a60-b112a1f9919f)
If the correct password is provided, the updated email will be seen in the dashboard (navigated to on submission):
![image](https://github.com/user-attachments/assets/429ca56a-b7ea-4b3e-836f-e9008199c495)
