### PR TITLE
CHORE: Change profile picture in nav with gear icon (TP-86)

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -4,8 +4,8 @@ import { useRouter } from "next/navigation";
 import CompanyLogo from "@/app/components/CompanyLogo";
 import Navbar from "@/app/components/Navbar";
 import LogoutBtn from "@/app/components/LogoutBtn";
-import Image from "next/image";
 import { getCurrentUser } from "@/lib/appwrite";
+import { Cog } from 'lucide-react';
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -37,8 +37,6 @@ export default function Header() {
   const handleParkingClick = () => {
     console.log("Parking btn clicked");
   };
-
-  const profileImage = "/Animal.jpg"; // TODO: Replace with the actual profile image source
 
   return (
     <header className="relative bg-white text-black py-4 px-6">
@@ -80,12 +78,9 @@ export default function Header() {
             <Navbar isMobile={false} />
             <div className="flex flex-row gap-4 items-center justify-center">
               <button>
-                <Image
-                  src={profileImage}
+                <Cog
                   width={40}
                   height={40}
-                  alt="Profile Picture"
-                  className="w-10 h-10 rounded-full object-cover"
                   onClick={() => router.push("/dashboard")}
                 />
               </button>

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -1,26 +1,11 @@
 import LABELS from '@/app/constants/labels';
 import Link from 'next/link';
 import NotificationBadge from '@/app/components/NotificationBadge';
-import { X, LogOut, Menu, ChevronRight } from 'lucide-react';
-import Image from 'next/image';
+import { X, LogOut, Menu, ChevronRight, Cog } from 'lucide-react';
 import ICON_MAP from '@/app/constants/icons';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { logout } from '@/lib/appwrite';
-
-const ProfileImage = ({ size = 40, className = '' }) => {
-  const profileImage = '/Animal.jpg'; // TODO: Replace with the actual profile image source
-
-  return (
-    <Image
-      src={profileImage}
-      width={size}
-      height={size}
-      alt='Profile Picture'
-      className={`rounded-full object-cover ${className}`}
-    />
-  );
-};
 
 interface NavbarProps {
   isMobile?: boolean;
@@ -73,9 +58,14 @@ export default function Navbar({
         <button className='absolute top-6 right-8' onClick={closeMenu}>
           <X size={36} />
         </button>
-        <div className='mt-16 flex flex-col items-center border-b border-black py-4'>
-          <ProfileImage size={100} />
-          <p className='mt-2 font-medium text-lg'>Hi, Animal!</p>
+        <div className='mt-16 flex flex-row py-4'>
+          <button 
+          className='flex flex-row gap-4 p-4 w-full items-center bg-secondary-blue text-white bg-gradient-to-r from-secondary-blue to-primary-green shadow-md' 
+          onClick={() => router.push("/dashboard")}>
+          <Cog size={50} />
+          <p>{LABELS.mobileNav.cogTitle}</p>
+          </button>
+
         </div>
         <div className='flex flex-col gap-6 pt-6 flex-grow'>
           {navigationData.map(([label, { href, text, icon }]) => (

--- a/src/app/constants/labels.ts
+++ b/src/app/constants/labels.ts
@@ -426,5 +426,8 @@ const LABELS = {
       pending: "Pending Signature",
     },
   },
+  mobileNav: {
+    cogTitle: 'Dashboard'
+  }
 }
 export default LABELS;


### PR DESCRIPTION
In this PR I changed the Animal profile pic with a gear icon in desktop view and a new button in the mobile view. Both now route to the dashboard giving the user a much easier way to navigate the application.

`Desktop`
<img width="1358" alt="Screenshot 2025-03-22 at 9 55 17 PM" src="https://github.com/user-attachments/assets/307c2191-44f7-4d11-921f-d67fb3f56d1f" />

`Mobile`
<img width="480" alt="Screenshot 2025-03-22 at 10 13 54 PM" src="https://github.com/user-attachments/assets/0e6b530b-f54e-456e-a457-30d428c2a6f1" />

