### PR TITLE
Fix: Feature Section colour branding (TP-92)

### DIFF
--- a/src/app/components/FeatureCard.tsx
+++ b/src/app/components/FeatureCard.tsx
@@ -9,7 +9,7 @@ export default function FeatureCard({ title, description }: FeatureCardProps) {
   return (
     <div className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow duration-300">
       <div className="mb-4">
-        <div className="w-10 h-10 bg-green-500 rounded-full flex items-center justify-center mb-4">
+        <div className="w-10 h-10 bg-primary-green rounded-full flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
           </svg>

--- a/src/app/components/FeatureHighlight.tsx
+++ b/src/app/components/FeatureHighlight.tsx
@@ -7,7 +7,7 @@ export default function FeatureHighlight() {
       <div className="container mx-auto px-6">
         <div className="mb-12 text-center">
           <h2 className="text-3xl md:text-4xl font-bold text-black mb-4">{LABELS.featureHighlight.title}</h2>
-          <div className="w-24 h-1 bg-green-500 mx-auto"></div>
+          <div className="w-24 h-1 bg-primary-green mx-auto"></div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
           {LABELS.featureHighlight.featureCards.map((feature) => (


### PR DESCRIPTION
changed colours of Card component and section title to match app branding schema

<img width="949" alt="image" src="https://github.com/user-attachments/assets/624f06e1-8a1f-4c18-bec3-972ae59b3da3" />
