### PR TITLE
fix: messages routing (TP-94)

### DIFF
--- a/src/app/constants/labels.ts
+++ b/src/app/constants/labels.ts
@@ -2,7 +2,7 @@ const LABELS = {
   loading: "Loading...",
   navigation: {
     messages: {
-      href: "/Messaging",
+      href: "/messaging",
       text: "Messages",
       icon: "messageIcon",
     },
@@ -203,7 +203,7 @@ const LABELS = {
   },
   adminDashboardBtns: {
     messages: {
-      href: "/Messaging",
+      href: "/messaging",
       text: "View Messages",
       icon: "mailIcon",
     },


### PR DESCRIPTION
- Changed directory folder to match 'lowercase' naming convention. 
- Updated href instances to match correct casing.

**May require developers to RESTART SERVER to take effect and function correctly**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f4044033-e0fc-4824-9417-f50c5b6ea557" />



<img width="665" alt="image" src="https://github.com/user-attachments/assets/11737016-6bdb-4d74-b1a1-ce0fdd3d87de" />
