### PR TITLE
Fix: redirect authenticated users away from /login (TP-105)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,8 +4,25 @@ import Image from "next/image"
 import Link from "next/link"
 import LoginForm from "../components/Loginform"
 import LABELS from "@/app/constants/labels"
+import { getCurrentUser } from "@/lib/appwrite"
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+
 
 export default function LoginPage() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const checkIfLoggedIn = async () => {
+      const response = await getCurrentUser()
+      if (response.success) {
+        router.push("/dashboard")
+      }
+    }
+
+    checkIfLoggedIn()
+  }, [router])
+
   return (
     <div className="min-h-screen bg-white flex flex-col lg:flex-row">
       <div className="hidden lg:block lg:w-1/2 h-screen relative">


### PR DESCRIPTION
This PR fixes a bug where authenticated users could access the /login page and encounter an "invalid password/email" error—even if they entered valid credentials.

- Added a useEffect to the `/login/page.tsx` file.
- Checks if a user is already authenticated using Appwrite’s `getCurrentUser()` function.
- If the user is logged in, automatically redirects them to` /dashboard.`