### PR TITLE
Fix: create "no lease found" error on tenant side, fix bug (TP-81)

### DIFF
--- a/src/app/components/lease/LeaseView.tsx
+++ b/src/app/components/lease/LeaseView.tsx
@@ -124,6 +124,15 @@ export default function LeaseView({ isAdmin = false }: LeaseViewProps) {
   if (!isAdmin) {
     const activeLease =
       leases.find((lease) => lease.leaseStatus === "active") || leases[0];
+    
+    if (!activeLease) {
+      return (
+        <div className="w-full max-w-3xl mx-auto bg-white rounded-xl shadow p-8 text-center">
+          <h2 className="text-xl font-semibold text-gray-800">No lease found</h2>
+          <p className="text-gray-600 mt-2">You don’t currently have an active lease assigned to your account.</p>
+        </div>
+      )
+    }
 
     return (
       <div className="w-full max-w-4xl mx-auto bg-white rounded-xl shadow-lg overflow-hidden">


### PR DESCRIPTION
This PR resolves an issue where non-admin (tenant) users encountered a runtime error when visiting the` /lease` page without any assigned or active leases. The application previously attempted to access properties on an undefined lease object, causing a crash.


1. Added a conditional check in `LeaseView.tsx `to ensure activeLease exists before rendering.
2. Rendered a fallback UI message when no lease is found for the user.