### PR TITLE
fix: footer not displaying proper styles on small screens (TP-120)

### DIFF
--- a/src/app/components/CompanyLogo.tsx
+++ b/src/app/components/CompanyLogo.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 
-export default function CompanyLogo() {
+export default function CompanyLogo({ isFooter = false }) {
+  const textColor = isFooter ? "text-white" : "text-black";
+
   return (
     <div className="flex items-end">
       <Link href="/" className="flex items-center cursor-pointer">
@@ -8,11 +10,11 @@ export default function CompanyLogo() {
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           fill="currentColor"
-          className="w-8 h-8 text-black"
+          className={`w-8 h-8 ${textColor}`}
         >
           <path d="M3 22V7.5L12 2l9 5.5V22h-7v-6h-4v6H3ZM5 20h4v-4h6v4h4V8.68l-7-4.28-7 4.28V20ZM7 10h2v2H7v-2Zm0 4h2v2H7v-2Zm4-4h2v2h-2v-2Zm0 4h2v2h-2v-2Zm4-4h2v2h-2v-2Zm0 4h2v2h-2v-2Z" />
         </svg>
-        <h1 className="text-2xl text-black mt-2">TENANT</h1>
+        <h1 className={`text-2xl ${isFooter} mt-2`}>TENANT</h1>
       </Link>
     </div>
   );

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useState, useEffect } from "react";
 import LogoutBtn from "./LogoutBtn";
 import { getCurrentUser } from "@/lib/appwrite";
+import CompanyLogo from "./CompanyLogo";
 
 const FooterData = {
   apartmentName: "Willow Creek Apartments",
@@ -19,8 +20,8 @@ const FooterData = {
 };
 
 const buttonStyles = {
-  signUp: "bg-primary-green text-white md:block hidden",
-  logout: "bg-primary-green text-white",
+  signUp: "bg-primary-green text-white ",
+  logout: "bg-primary-green text-white ",
 };
 
 const Footer = () => {
@@ -40,11 +41,11 @@ const Footer = () => {
   }, []);
 
   return (
-    <div className="bg-alternate-light-gray md:bg-secondary-blue flex justify-between p-8">
-      <div className=" md:text-alternate-light-gray md:block hidden">
+    <div className="bg-secondary-blue flex justify-between p-8 items-center">
+      <div className="text-alternate-light-gray hidden md:block w-1/2">
         <p className="text-3xl py-2">{FooterData.apartmentName}</p>
         <p className="tracking-wider">Address: {FooterData.address}</p>
-        <div className="flex justify-center gap-1 tracking-wider">
+        <div className="flex gap-1 tracking-wider">
           <p className="">Website:</p>
           <Link className="underline" href={FooterData.website}>
             {FooterData.website}
@@ -53,11 +54,9 @@ const Footer = () => {
         <p className="tracking-wider">Phone: {FooterData.phone}</p>
       </div>
 
-      <div className="flex items-center gap-10">
+      <div className="flex items-center  gap-4 text-white ml-auto">
         {isLoggedIn ? (
-          <LogoutBtn 
-          bgColor="bg-primary-green"
-          />
+          <LogoutBtn bgColor="bg-primary-green" />
         ) : (
           <Button
             href={LABELS.buttons.FooterLogin.href}
@@ -66,9 +65,7 @@ const Footer = () => {
           />
         )}
 
-        <h1 className="text-3xl md:text-2xl font-semibold text-primary-black md:text-alternate-light-gray uppercase">
-          {FooterData.logoName}
-        </h1>
+        <CompanyLogo isFooter />
       </div>
     </div>
   );


### PR DESCRIPTION
- Adjusted styling for footer so that styling is displayed properly on small screens. 
- Added props to logo to render white on footer and black on header
- Adjusted Property information to align better.

Footer on small screens (No property info displayed on small screens): 
<img width="700" alt="Screenshot 2025-03-26 at 2 16 42 PM" src="https://github.com/user-attachments/assets/42080116-b101-40e2-b97f-31e36ca1cecb" />

Property info adjusted on larger screens:
<img width="1258" alt="Screenshot 2025-03-26 at 2 27 37 PM" src="https://github.com/user-attachments/assets/4b642d3f-8a1b-4312-8bf9-1e9954c58ea5" />


Logo in header unaffected: 
<img width="552" alt="Screenshot 2025-03-26 at 2 17 04 PM" src="https://github.com/user-attachments/assets/e4faa03c-6d04-4f8c-9c14-09e9547a4fda" />
