### PR TITLE
fix: move edit profile badge on mobile view (TP-122)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -197,7 +197,7 @@ const Dashboard = () => {
     return (
       <Link
         href="/editProfile"
-        className={`${buttonColor} ${hiddenButton} border-4 border-white p-1 rounded-lg relative left-10 bottom-[110px] lg:static lg:border-none lg:px-4 lg:py-2 lg:mt-4 transition-all duration-200 ease-in-out`}
+        className={`${buttonColor} ${hiddenButton} border-2 border-white p-1 rounded-lg relative left-10 bottom-[8rem] lg:static lg:border-none lg:px-4 lg:py-2 lg:mt-4 transition-all duration-200 ease-in-out`}
       >
         <div className="block lg:hidden">
           <Pencil size={16} fill="white" />


### PR DESCRIPTION
reduced border radius and moved badge to be absolutely referenced with REM vs pixels
<img width="265" alt="image" src="https://github.com/user-attachments/assets/1685ef87-ba7a-4b0d-a230-ad3efbb7d48f" />
